### PR TITLE
Feature: filtering

### DIFF
--- a/build/plux.js
+++ b/build/plux.js
@@ -44,16 +44,20 @@
             var _this = this;
 
             this.subscriptions.forEach(function (subscription) {
-              return subscription[1](Object.assign({}, _this.state));
+              var filter = subscription[2];
+              var results = filter ? filter(_this.state) : _this.state;
+              if (results) {
+                subscription[1](Object.assign({}, results));
+              }
             });
           }
         };
       },
       // Subscribe to listen to any changes that affect a view.
-      'subscribe': function subscribe(storeName, subscriber) {
+      'subscribe': function subscribe(storeName, subscriber, filter) {
         subscriptionCounters[storeName] = subscriptionCounters[storeName] || 0;
         var subid = subscriptionCounters[storeName]++;
-        stores[storeName].subscriptions.push([subid, subscriber]);
+        stores[storeName].subscriptions.push([subid, subscriber, filter]);
         subscriber(stores[storeName].state);
         return {
           "unsubscribe": function unsubscribe() {

--- a/src/plux.js
+++ b/src/plux.js
@@ -44,7 +44,6 @@ const plux = (() => {
       subscriptionCounters[storeName] = subscriptionCounters[storeName] || 0
       const subid = subscriptionCounters[storeName]++;
       stores[storeName].subscriptions.push([subid, subscriber, filter]);
-      subscriber(stores[storeName].state);
       return {
         "unsubscribe": () => unsubscribe(storeName, subid),
         "id": subid,

--- a/src/plux.js
+++ b/src/plux.js
@@ -32,7 +32,7 @@ const plux = (() => {
           this.subscriptions.forEach((subscription) => {
             const filter = subscription[2];
             const results = filter ? filter(this.state) : this.state;
-            if(results){
+            if(results !== false){
               subscription[1](Object.assign({}, results));
             }
           });

--- a/src/plux.js
+++ b/src/plux.js
@@ -29,15 +29,21 @@ const plux = (() => {
         'handleAction': actionHandler,
         'subscriptions': [],
         'notify': function(subscriptions){
-          this.subscriptions.forEach((subscription) => subscription[1](Object.assign({}, this.state)));
+          this.subscriptions.forEach((subscription) => {
+            const filter = subscription[2];
+            const results = filter ? filter(this.state) : this.state;
+            if(results){
+              subscription[1](Object.assign({}, results));
+            }
+          });
         }
       };
     },
     // Subscribe to listen to any changes that affect a view.
-    'subscribe': (storeName, subscriber) => {
+    'subscribe': (storeName, subscriber, filter) => {
       subscriptionCounters[storeName] = subscriptionCounters[storeName] || 0
       const subid = subscriptionCounters[storeName]++;
-      stores[storeName].subscriptions.push([subid, subscriber]);
+      stores[storeName].subscriptions.push([subid, subscriber, filter]);
       subscriber(stores[storeName].state);
       return {
         "unsubscribe": () => unsubscribe(storeName, subid),


### PR DESCRIPTION
This feature includes breaking changes.

When subscribing to a store, you can now specify a filtering function that will be called before the subscribed function is called. If this function returns a non-false value, then the subscribing function will be called with what's returned by the filter function. This further allows for specific data to be extracted before being sent to the subscribing function. It should be noted though that the filtering function will be called every time the state is changed.  It's not advisable to include heavy operations here. Conversely, a smart filtering function will spare calls to subscribed functions that are doing heavy lifting.

This feature eliminates the initial call to the subscribing function when the subscription is created (but before any actions have been called.) If you need the state prior to an action being called but after the subscription is created, use plux.getState instead.