### PR TITLE
Bugfix: unsubscribe

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plux",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A simple flux implementation.",
   "main": "build/plux.js",
   "dependencies": {},

--- a/src/plux.js
+++ b/src/plux.js
@@ -19,7 +19,9 @@ const plux = (() => {
   };
   const unsubscribe = (storeName, id) => {
     let subscriptionIndex = stores[storeName].subscriptions.findIndex((entry) => entry[0] == id);
-    stores[storeName].subscriptions.splice(subscriptionIndex, 1);
+    if(subscriptionIndex >= 0){
+      stores[storeName].subscriptions.splice(subscriptionIndex, 1);
+    }
   };
   const API = {
     // Register a store with plux to receive actions and manage state.


### PR DESCRIPTION
Since the unsubscribe method can be called multiple times, it's possible for a store to search for a subscriber that no longer exists. This results in an index of -1, which is a valid argument for splice, and will remove a still active subscription erroneously. This change adds a check to ensure that does not happen.