### PR TITLE
Feature: events

### DIFF
--- a/build/plux.js
+++ b/build/plux.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
-    define(['module'], factory);
+    define(["module"], factory);
   } else if (typeof exports !== "undefined") {
     factory(module);
   } else {
@@ -15,23 +15,76 @@
   // Based on description here:
   // https://github.com/facebook/flux/tree/master/examples/flux-concepts
 
+  var _slicedToArray = function () {
+    function sliceIterator(arr, i) {
+      var _arr = [];
+      var _n = true;
+      var _d = false;
+      var _e = undefined;
+
+      try {
+        for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) {
+          _arr.push(_s.value);
+
+          if (i && _arr.length === i) break;
+        }
+      } catch (err) {
+        _d = true;
+        _e = err;
+      } finally {
+        try {
+          if (!_n && _i["return"]) _i["return"]();
+        } finally {
+          if (_d) throw _e;
+        }
+      }
+
+      return _arr;
+    }
+
+    return function (arr, i) {
+      if (Array.isArray(arr)) {
+        return arr;
+      } else if (Symbol.iterator in Object(arr)) {
+        return sliceIterator(arr, i);
+      } else {
+        throw new TypeError("Invalid attempt to destructure non-iterable instance");
+      }
+    };
+  }();
+
   var plux = function () {
     var stores = []; // Contains references to all stores.
     var subscriptionCounters = []; // Tracks IDs to assign to subscribers
     var dispatch = function dispatch(action, data) {
+      var _loop = function _loop(storeID) {
+        var store = stores[storeID];
+        // Collect events
+        var events = new Set();
+        var change = function change() {
+          var event = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "change";
+          return events.add(event);
+        };
+        // Handle the action and trigger any mutations.
+        store.handleAction(action, data, store.state, change);
+        events.add("change");
+        events.forEach(function (event) {
+          return store.notify(store.subscriptions, event);
+        });
+      };
+
       // Iterate through all registered stores to dispatch the action.
       for (var storeID in stores) {
-        var store = stores[storeID];
-        // Handle the action and trigger any mutations.
-        store.handleAction(action, data, store.state);
-        store.notify(store.subscriptions);
+        _loop(storeID);
       };
     };
     var _unsubscribe = function _unsubscribe(storeName, id) {
       var subscriptionIndex = stores[storeName].subscriptions.findIndex(function (entry) {
         return entry[0] == id;
       });
-      stores[storeName].subscriptions.splice(subscriptionIndex, 1);
+      if (subscriptionIndex >= 0) {
+        stores[storeName].subscriptions.splice(subscriptionIndex, 1);
+      }
     };
     var API = {
       // Register a store with plux to receive actions and manage state.
@@ -40,25 +93,27 @@
           'state': initial || {},
           'handleAction': actionHandler,
           'subscriptions': [],
-          'notify': function notify(subscriptions) {
+          'notify': function notify(subscriptions, event) {
             var _this = this;
 
-            this.subscriptions.forEach(function (subscription) {
-              var filter = subscription[2];
-              var results = filter ? filter(_this.state) : _this.state;
-              if (results) {
-                subscription[1](Object.assign({}, results));
-              }
+            this.subscriptions.filter(function (_ref) {
+              var _ref2 = _slicedToArray(_ref, 3),
+                  subEvent = _ref2[2];
+
+              return event === subEvent || subEvent === "_all";
+            }).forEach(function (subscription) {
+              return subscription[1](Object.assign({}, _this.state));
             });
           }
         };
       },
-      // Subscribe to listen to any changes that affect a view.
-      'subscribe': function subscribe(storeName, subscriber, filter) {
+      // Subscribe to listen to any changes that affect a view. Optionally specify an event to filter by.
+      'subscribe': function subscribe(storeName, subscriber) {
+        var event = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : "change";
+
         subscriptionCounters[storeName] = subscriptionCounters[storeName] || 0;
         var subid = subscriptionCounters[storeName]++;
-        stores[storeName].subscriptions.push([subid, subscriber, filter]);
-        subscriber(stores[storeName].state);
+        stores[storeName].subscriptions.push([subid, subscriber, event]);
         return {
           "unsubscribe": function unsubscribe() {
             return _unsubscribe(storeName, subid);
@@ -66,6 +121,10 @@
           "id": subid,
           "store": storeName
         };
+      },
+      // Listen is almost the same as subscribe, but it emphasizes an event you want to listen for, rather than a store you want to subscribe to.
+      'listen': function listen(storeName, event, listener) {
+        return this.subscribe(storeName, listener, event);
       },
       // Register an action that's available for views to trigger.
       'createAction': function createAction(name) {

--- a/build/plux.js
+++ b/build/plux.js
@@ -102,7 +102,7 @@
 
               return event === subEvent || subEvent === "_all";
             }).forEach(function (subscription) {
-              return subscription[1](Object.assign({}, _this.state));
+              return subscription[1](Object.assign({}, _this.state), event);
             });
           }
         };

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -10,6 +10,7 @@
         function updateValues(count){
             $("#incCount").text(count);
         }
+        updateValues(plux.getState("shared").count);
         // Let's wire up the button to trigger an action to the dispatcher.
         $("#inc button").click(function(){
             actions.increment();
@@ -30,6 +31,7 @@
         function updateValues(count){
             $("#decCount").text(count);
         }
+        updateValues(plux.getState("shared").count);
         // Let's wire up the button to trigger an action to the dispatcher.
         $("#dec button").click(function(){
             actions.decrement();
@@ -45,5 +47,19 @@
         $("#reset").click(function(){
             actions.initialize();
         });
+    });
+})();
+
+// Reset Element
+(function(){
+    $(document).ready(function() {
+        const messages = [];
+        function log(msg) {
+            messages.unshift(msg);
+            $("#log").html(messages.join("<br/>"))
+        }
+        plux.listen("shared", "incremented", () => log("The count has been increased!"));
+        plux.listen("shared", "decremented", () => log("The count has been decreased!"));
+        plux.listen("shared", "initialized", () => log("The count has been initialized to 0."));
     });
 })();

--- a/demo/index.html
+++ b/demo/index.html
@@ -36,6 +36,8 @@
                 </td>
             </tr>
         </table>
+        <div id="log" style="font-family:monospace; text-align:center; max-height:500px; width:600px;">
+        </div>
         <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
         <script src="../build/plux.js"></script>
         <script src="store.js"></script>

--- a/demo/store.js
+++ b/demo/store.js
@@ -1,15 +1,18 @@
 // A sample store file.
 (function(){
-    var myActionHandler = function(action, data, state){
+    var myActionHandler = function(action, data, state, event){
         switch(action){
             case "initialize":
                 state.count = 0;
+                event("initialized");
                 break;
             case "increment":
                 state.count++;
+                event("incremented");
                 break;
             case "decrement":
                 state.count--;
+                event("decremented");
                 break;
         }
     };

--- a/src/plux.js
+++ b/src/plux.js
@@ -40,7 +40,7 @@ const plux = (() => {
         }
       };
     },
-    // Subscribe to listen to any changes that affect a view.
+    // Subscribe to listen to any changes that affect a view. Optionally specify an event to filter by.
     'subscribe': (storeName, subscriber, event="change") => {
       subscriptionCounters[storeName] = subscriptionCounters[storeName] || 0
       const subid = subscriptionCounters[storeName]++;
@@ -50,6 +50,10 @@ const plux = (() => {
         "id": subid,
         "store": storeName
       }
+    },
+    // Listen is almost the same as subscribe, but it emphasizes an event you want to listen for, rather than a store you want to subscribe to.
+    'listen': function(storeName, event, listener){
+      return this.subscribe(storeName, listener, event);
     },
     // Register an action that's available for views to trigger.
     'createAction': (name) => (data) => dispatch(name, data),

--- a/src/plux.js
+++ b/src/plux.js
@@ -36,7 +36,7 @@ const plux = (() => {
         'handleAction': actionHandler,
         'subscriptions': [],
         'notify': function(subscriptions, event){
-          this.subscriptions.filter(([,,subEvent]) => event === subEvent || subEvent === "_all").forEach((subscription) => subscription[1](Object.assign({}, this.state)));
+          this.subscriptions.filter(([,,subEvent]) => event === subEvent || subEvent === "_all").forEach((subscription) => subscription[1](Object.assign({}, this.state), event));
         }
       };
     },

--- a/src/plux.js
+++ b/src/plux.js
@@ -8,13 +8,18 @@ const plux = (() => {
     // Iterate through all registered stores to dispatch the action.
     for(let storeID in stores){
       let store = stores[storeID];
+      // Collect events
+      let events = new Set();
+      let change = (event="change") => events.add(event);
       // Handle the action and trigger any mutations.
       store.handleAction(
         action, 
         data, 
-        store.state
+        store.state,
+        change
       );
-      store.notify(store.subscriptions);
+      events.add("change");
+      events.forEach((event) => store.notify(store.subscriptions, event));
     };
   };
   const unsubscribe = (storeName, id) => {
@@ -30,22 +35,16 @@ const plux = (() => {
         'state': initial || {},
         'handleAction': actionHandler,
         'subscriptions': [],
-        'notify': function(subscriptions){
-          this.subscriptions.forEach((subscription) => {
-            const filter = subscription[2];
-            const results = filter ? filter(this.state) : this.state;
-            if(results !== false){
-              subscription[1](Object.assign({}, results));
-            }
-          });
+        'notify': function(subscriptions, event){
+          this.subscriptions.filter(([,,subEvent]) => event === subEvent || subEvent === "_all").forEach((subscription) => subscription[1](Object.assign({}, this.state)));
         }
       };
     },
     // Subscribe to listen to any changes that affect a view.
-    'subscribe': (storeName, subscriber, filter) => {
+    'subscribe': (storeName, subscriber, event="change") => {
       subscriptionCounters[storeName] = subscriptionCounters[storeName] || 0
       const subid = subscriptionCounters[storeName]++;
-      stores[storeName].subscriptions.push([subid, subscriber, filter]);
+      stores[storeName].subscriptions.push([subid, subscriber, event]);
       return {
         "unsubscribe": () => unsubscribe(storeName, subid),
         "id": subid,

--- a/tests/index.js
+++ b/tests/index.js
@@ -20,10 +20,11 @@ describe(`Plux API`, function() {
 describe(`createStore`, function() {
   it('should accept an action handler that is called for every action', function() {
     let handlerCalled = false;
-    let actionHandler = (action, data, state) => {
+    let actionHandler = (action, data, state, event) => {
         switch(action){
             case "anAction":
                 handlerCalled = true;
+                event();
                 break;
         }
     };
@@ -34,9 +35,10 @@ describe(`createStore`, function() {
 
   it('should allow for subscriptions to the new store', function() {
     let subscriptionCalled = 0;
-    let actionHandler = function(action, data, state){
+    let actionHandler = function(action, data, state, event){
         switch(action){
             case "anAction":
+                event();
                 break;
         }
     };
@@ -50,10 +52,11 @@ describe(`createStore`, function() {
 
   it('should allow for state retrieval for the new store', function() {
     let subscriptionCalled = false;
-    let actionHandler = function(action, data, state){
+    let actionHandler = function(action, data, state, event){
         switch(action){
             case "anAction":
               state.hello = data;
+                event();
                 break;
         }
     };
@@ -71,9 +74,10 @@ describe(`createStore`, function() {
 describe(`subscribe`, function() {
   it('should return an API with two properties and a method', function() {
     let subscriptionCalled = 0;
-    let actionHandler = function(action, data, state){
+    let actionHandler = function(action, data, state, event){
         switch(action){
             case "anAction":
+                event();
                 break;
         }
     };
@@ -90,9 +94,10 @@ describe(`subscribe`, function() {
 
   it('should accept a callback function that receives all state updates', function() {
     let subscriptionCalled = 0;
-    let actionHandler = function(action, data, state){
+    let actionHandler = function(action, data, state, event){
         switch(action){
             case "anAction":
+                event();
                 break;
         }
     };
@@ -104,63 +109,12 @@ describe(`subscribe`, function() {
     expect(subscriptionCalled).to.be.equal(1);
   });
 
-  it('should accept a filter function that is called before the subscriber function', function() {
-    let callCount = 0;
-    let subscriptionLastCall = null;
-    let filterLastCall = null;
-    let actionHandler = function(action, data, state){
-        switch(action){
-            case "anAction":
-                break;
-        }
-    };
-    plux.createStore("test-0716-1", actionHandler, { }); 
-    let anAction = plux.createAction("anAction");
-    plux.subscribe("test-0716-1", (state) => subscriptionLastCall = callCount++, (state) => { filterLastCall = callCount++; return state; });
-    anAction();
-    expect(filterLastCall).to.be.equal(0);
-    expect(subscriptionLastCall).to.be.equal(1);
-  });
-
-  it('should only call the subscriber function if the filter function returns a non-false value', function() {
-    let subscriberCalls = 0;
-    let filterCalls = 0;
-    let actionHandler = function(action, data, state){
-        switch(action){
-            case "anAction":
-                break;
-        }
-    };
-    plux.createStore("test-0716-2", actionHandler, { }); 
-    let anAction = plux.createAction("anAction");
-    plux.subscribe("test-0716-2", (state) => subscriberCalls++, (state) => ++filterCalls % 2 == 0 ? state : false );
-    anAction();
-    expect(filterCalls).to.be.equal(1);
-    expect(subscriberCalls).to.be.equal(0);
-    anAction();
-    expect(filterCalls).to.be.equal(2);
-    expect(subscriberCalls).to.be.equal(1);
-  });
-
-  it('should call the subscriber with the value returned by the filter function', function() {
-    let actionHandler = function(action, data, state){
-        switch(action){
-            case "anAction":
-                break;
-        }
-    };
-    plux.createStore("test-0716-3", actionHandler, { }); 
-    let anAction = plux.createAction("anAction");
-    const subscription = plux.subscribe("test-0716-3", (state) => expect(state.answer).to.be.equal(42), (state) => { return { 'answer': 42 } } );
-    anAction();
-    subscription.unsubscribe();
-  });
-
   it('should stop sending state updates to callback after unsubscribe is called', function() {
     let subscriptionCalled = 0;
-    let actionHandler = function(action, data, state){
+    let actionHandler = function(action, data, state, event){
         switch(action){
             case "anAction":
+                event();
                 break;
         }
     };
@@ -174,15 +128,69 @@ describe(`subscribe`, function() {
     expect(subscriptionCalled).to.be.equal(1);
   });
 
+  it('should allow you to subscribe to listen only for specific events', function() {
+    let subscriptionCalledA = 0;
+    let subscriptionCalledB = 0;
+    let actionHandler = function(action, data, state, event){
+        switch(action){
+            case "anAction":
+                event("hello");
+                event("world");
+                break;
+        }
+    };
+    plux.createStore("test-0727-1", actionHandler, { }); 
+    let anAction = plux.createAction("anAction");
+    plux.subscribe("test-0727-1", (state) => subscriptionCalledA++, "hello");
+    plux.subscribe("test-0727-1", (state) => subscriptionCalledB++, "world");
+    anAction();
+    expect(subscriptionCalledA).to.be.equal(1);
+    expect(subscriptionCalledB).to.be.equal(1);
+  });
+
+  it('should ensure that a change event always fires if a custom event fires', function() {
+    let subscriptionCalled = 0;
+    let actionHandler = function(action, data, state, event){
+        switch(action){
+            case "anAction":
+                event("hello");
+                break;
+        }
+    };
+    plux.createStore("test-0727-2", actionHandler, { }); 
+    let anAction = plux.createAction("anAction");
+    plux.subscribe("test-0727-2", (state) => subscriptionCalled++, "change");
+    anAction();
+    expect(subscriptionCalled).to.be.equal(1);
+  });
+
+  it('should allow you to subscribe to all events', function() {
+    let subscriptionCalled = 0;
+    let actionHandler = function(action, data, state, event){
+        switch(action){
+            case "anAction":
+                event("hello");
+                event("world");
+                break;
+        }
+    };
+    plux.createStore("test-0727-3", actionHandler, { }); 
+    let anAction = plux.createAction("anAction");
+    plux.subscribe("test-0727-3", (state) => subscriptionCalled++, "_all");
+    anAction();
+    expect(subscriptionCalled).to.be.equal(3);
+  });
+
 });
 
 describe(`createAction`, function() {
   it('should return a callable method that invokes the given action against all stores with specified data', function() {
     let subscriptionCalled = false;
-    let actionHandler = function(action, data, state){
+    let actionHandler = function(action, data, state, event){
         switch(action){
             case "anAction":
               state.hello = data;
+                event();
                 break;
         }
     };
@@ -200,10 +208,11 @@ describe(`createAction`, function() {
 
 describe(`getState`, function() {
   it('should return an object representative of the state held by the specified store', function() {
-    let actionHandler = function(action, data, state){
+    let actionHandler = function(action, data, state, event){
         switch(action){
             case "anAction":
               state.hello = data;
+                event();
                 break;
         }
     };

--- a/tests/index.js
+++ b/tests/index.js
@@ -14,6 +14,8 @@ describe(`Plux API`, function() {
     expect(plux.createAction).to.be.a("function");
     expect(plux).to.have.a.property('getState');
     expect(plux.getState).to.be.a("function");
+    expect(plux).to.have.a.property('listen');
+    expect(plux.getState).to.be.a("function");
   });
 });
 
@@ -131,6 +133,8 @@ describe(`subscribe`, function() {
   it('should allow you to subscribe to listen only for specific events', function() {
     let subscriptionCalledA = 0;
     let subscriptionCalledB = 0;
+    let altSubscriptionCalledA = 0;
+    let altSubscriptionCalledB = 0;
     let actionHandler = function(action, data, state, event){
         switch(action){
             case "anAction":
@@ -143,9 +147,15 @@ describe(`subscribe`, function() {
     let anAction = plux.createAction("anAction");
     plux.subscribe("test-0727-1", (state) => subscriptionCalledA++, "hello");
     plux.subscribe("test-0727-1", (state) => subscriptionCalledB++, "world");
+    plux.listen("test-0727-1", "hello", (state) => altSubscriptionCalledA++);
+    plux.listen("test-0727-1", "world", (state) => altSubscriptionCalledB++);
     anAction();
+    // via plux.subscribe
     expect(subscriptionCalledA).to.be.equal(1);
     expect(subscriptionCalledB).to.be.equal(1);
+    // via plux.listen
+    expect(altSubscriptionCalledA).to.be.equal(1);
+    expect(altSubscriptionCalledB).to.be.equal(1);
   });
 
   it('should ensure that a change event always fires if a custom event fires', function() {


### PR DESCRIPTION
This set of changes switches plux from using filters to control when a subscription is notified to using an event based system.  The filters would be called for EVERY action, and would have to be set for EVERY subscription. This is far from optimal, and I realize that transitioning to an event based system is necessary to keep the cost of subscriptions low.

This will include breaking functionality.
 - Stores must now emit events in order for subscriptions to be notified.
 - Filters have been removed.

A change event will always be emitted even if only a custom event is called.
When subscribing, you can now optionally specify an event for the subscription to be notified on.
Alternatively, you can use the listen function on the plux API that explicitly requires an event to listen for. If you use `_all` as the name of the event, then every event will result in the subscriber being notified.