### PR TITLE
Feature: store enhancements

### DIFF
--- a/build/plux.js
+++ b/build/plux.js
@@ -93,6 +93,7 @@
           'state': initial || {},
           'handleAction': actionHandler,
           'subscriptions': [],
+          'getters': {},
           'notify': function notify(subscriptions, event) {
             var _this = this;
 
@@ -104,6 +105,26 @@
             }).forEach(function (subscription) {
               return subscription[1](Object.assign({}, _this.state), event);
             });
+          }
+        };
+        var plux = this;
+        return {
+          'name': name,
+          'subscribe': function subscribe(subscriber) {
+            var event = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : "change";
+            return plux.subscribe(name, subscriber, event);
+          },
+          'listen': function listen(event, subscriber) {
+            return plux.listen(name, event, subscriber);
+          },
+          'get': function get(getter) {
+            if (!getter) {
+              return Object.assign({}, stores[name].state);
+            }
+            return stores[name].getters[getter] ? stores[name].getters[getter](stores[name].state) : null;
+          },
+          'createGetter': function createGetter(getterName, getterFunction) {
+            return stores[name].getters[getterName] = getterFunction;
           }
         };
       },

--- a/src/plux.js
+++ b/src/plux.js
@@ -30,15 +30,24 @@ const plux = (() => {
   };
   const API = {
     // Register a store with plux to receive actions and manage state.
-    'createStore': (name, actionHandler, initial) => {
+    'createStore': function(name, actionHandler, initial){
       stores[name] = stores[name] || {
         'state': initial || {},
         'handleAction': actionHandler,
         'subscriptions': [],
+        'getters': {},
         'notify': function(subscriptions, event){
           this.subscriptions.filter(([,,subEvent]) => event === subEvent || subEvent === "_all").forEach((subscription) => subscription[1](Object.assign({}, this.state), event));
         }
       };
+      const plux = this;
+      return {
+        'name': name,
+        'subscribe': function(subscriber, event="change"){ return plux.subscribe(name, subscriber, event); },
+        'listen': function(event, subscriber){ return plux.listen(name, event, subscriber); },
+        'get': (getter) => stores[name].getters[getter] ? stores[name].getters[getter](stores[name].state) : null,
+        'createGetter': (getterName, getterFunction) => stores[name].getters[getterName] = getterFunction,
+      }
     },
     // Subscribe to listen to any changes that affect a view. Optionally specify an event to filter by.
     'subscribe': (storeName, subscriber, event="change") => {

--- a/src/plux.js
+++ b/src/plux.js
@@ -45,7 +45,12 @@ const plux = (() => {
         'name': name,
         'subscribe': function(subscriber, event="change"){ return plux.subscribe(name, subscriber, event); },
         'listen': function(event, subscriber){ return plux.listen(name, event, subscriber); },
-        'get': (getter) => stores[name].getters[getter] ? stores[name].getters[getter](stores[name].state) : null,
+        'get': (getter) => {
+          if(!getter){
+            return Object.assign({}, stores[name].state);
+          }
+          return stores[name].getters[getter] ? stores[name].getters[getter](stores[name].state) : null
+        },
         'createGetter': (getterName, getterFunction) => stores[name].getters[getterName] = getterFunction,
       }
     },

--- a/tests/index.js
+++ b/tests/index.js
@@ -3,9 +3,13 @@
 var expect = require('chai').expect;
 var plux = require('../src/plux');
 
+var i = 0;
+function generateName(){
+    return `store${i++}`;
+}
 
 describe(`Plux API`, function() {
-  it('should have four primary API methods', function() {
+  it('should have five primary API methods', function() {
     expect(plux).to.have.a.property('createStore');
     expect(plux.createStore).to.be.a("function");
     expect(plux).to.have.a.property('subscribe');
@@ -20,6 +24,28 @@ describe(`Plux API`, function() {
 });
 
 describe(`createStore`, function() {
+  it('should return an API with 5 properties/methods and the name should match what was submitted', function() {
+    let actionHandler = (action, data, state, event) => {
+        switch(action){
+            case "anAction":
+                event();
+                break;
+        }
+    };
+    let sharedStore = plux.createStore("test-0727-5", actionHandler, {}); 
+    expect(sharedStore).to.have.a.property('name');
+    expect(sharedStore.name).to.be.a("string");
+    expect(sharedStore.name).to.equal("test-0727-5");
+    expect(sharedStore).to.have.a.property('subscribe');
+    expect(sharedStore.subscribe).to.be.a("function");
+    expect(sharedStore).to.have.a.property('listen');
+    expect(sharedStore.listen).to.be.a("function");
+    expect(sharedStore).to.have.a.property('get');
+    expect(sharedStore.get).to.be.a("function");
+    expect(sharedStore).to.have.a.property('createGetter');
+    expect(sharedStore.createGetter).to.be.a("function");
+  });
+
   it('should accept an action handler that is called for every action', function() {
     let handlerCalled = false;
     let actionHandler = (action, data, state, event) => {
@@ -35,7 +61,7 @@ describe(`createStore`, function() {
     expect(handlerCalled).to.be.true;
   });
 
-  it('should allow for subscriptions to the new store', function() {
+  it('should allow for subscriptions to the new store, via plux', function() {
     let subscriptionCalled = 0;
     let actionHandler = function(action, data, state, event){
         switch(action){
@@ -52,7 +78,24 @@ describe(`createStore`, function() {
     expect(subscriptionCalled).to.be.equal(1);
   });
 
-  it('should allow for state retrieval for the new store', function() {
+  it('should allow for subscriptions to the new store, via the store itself', function() {
+    let subscriptionCalled = 0;
+    let actionHandler = function(action, data, state, event){
+        switch(action){
+            case "anAction":
+                event();
+                break;
+        }
+    };
+    let sharedStore = plux.createStore("test-0727-4", actionHandler, { }); 
+    let anAction = plux.createAction("anAction");
+    sharedStore.subscribe((state) => subscriptionCalled++);
+    expect(subscriptionCalled).to.be.equal(0);
+    anAction();
+    expect(subscriptionCalled).to.be.equal(1);
+  });
+
+  it('should allow for state retrieval for the new store, via plux', function() {
     let subscriptionCalled = false;
     let actionHandler = function(action, data, state, event){
         switch(action){
@@ -69,6 +112,35 @@ describe(`createStore`, function() {
     expect(currentState).to.be.ok;
     expect(currentState).to.have.property('hello');
     expect(currentState.hello).to.be.equal("world");
+  });
+
+  it('should return an object that includes a get function that returns the state if no arguments are included', function() {
+    let subscriptionCalled = 0;
+    let actionHandler = function(action, data, state, event){
+        switch(action){
+            case "anAction":
+                event();
+                break;
+        }
+    };
+    let sharedStore = plux.createStore("test-0727-6", actionHandler, { 'hello': 'world' }); 
+    let myState = sharedStore.get();
+    expect(myState.hello).to.be.equal('world');
+  });
+
+  it('should return an object that includes a createGetter function that creates new getters on the store', function() {
+    let subscriptionCalled = 0;
+    let actionHandler = function(action, data, state, event){
+        switch(action){
+            case "anAction":
+                event();
+                break;
+        }
+    };
+    let sharedStore = plux.createStore("test-0727-7", actionHandler, { 'hello': 'world' }); 
+    sharedStore.createGetter("test", (state) => state.hello);
+    let myValue = sharedStore.get("test");
+    expect(myValue).to.be.equal('world');
   });
 
 });


### PR DESCRIPTION
Stores were originally just data and functions that were registered with plux. This set of changes enhances them to become their own objects that can be referenced and interacted with. New features on the store API include:
 - getters to retrieve the store's state, or data derived from the state
 - the ability to subscribe or listen to the store via the store itself