### PR TITLE
Feature: once (again)

### DIFF
--- a/build/plux.js
+++ b/build/plux.js
@@ -125,6 +125,9 @@
           },
           'createGetter': function createGetter(getterName, getterFunction) {
             return stores[name].getters[getterName] = getterFunction;
+          },
+          'once': function once(event, callback) {
+            return plux.once(name, event, callback);
           }
         };
       },
@@ -146,6 +149,15 @@
       // Listen is almost the same as subscribe, but it emphasizes an event you want to listen for, rather than a store you want to subscribe to.
       'listen': function listen(storeName, event, listener) {
         return this.subscribe(storeName, listener, event);
+      },
+      'once': function once(storeName, event, callback) {
+        var listener = this.listen(storeName, event, function (state, event) {
+          callback(state, event);
+          listener.unsubscribe();
+        });
+        return { 'cancel': function cancel() {
+            return listener.unsubscribe();
+          } };
       },
       // Register an action that's available for views to trigger.
       'createAction': function createAction(name) {

--- a/src/plux.js
+++ b/src/plux.js
@@ -52,6 +52,7 @@ const plux = (() => {
           return stores[name].getters[getter] ? stores[name].getters[getter](stores[name].state) : null
         },
         'createGetter': (getterName, getterFunction) => stores[name].getters[getterName] = getterFunction,
+        'once': function(event, callback){ return plux.once(name, event, callback); },
       }
     },
     // Subscribe to listen to any changes that affect a view. Optionally specify an event to filter by.
@@ -68,6 +69,13 @@ const plux = (() => {
     // Listen is almost the same as subscribe, but it emphasizes an event you want to listen for, rather than a store you want to subscribe to.
     'listen': function(storeName, event, listener){
       return this.subscribe(storeName, listener, event);
+    },
+    'once': function once(storeName, event, callback) {
+      const listener = this.listen(storeName, event, (state, event) => {
+        callback(state, event);
+        listener.unsubscribe();
+      });
+      return { 'cancel': () => listener.unsubscribe() }
     },
     // Register an action that's available for views to trigger.
     'createAction': (name) => (data) => dispatch(name, data),


### PR DESCRIPTION
This feature allows you to set a listener that executes one time when a specified event is emitted, and then unsubscribes.